### PR TITLE
[nrf fromlist] modules: hal_nordic: fixed wrong 802.15.4 NET core ini…

### DIFF
--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
@@ -19,4 +19,4 @@ static int serialization_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(serialization_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(serialization_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
…t level

The intialization level of 802.15.4 on NET core was set to APPLICATION,
which caused some applications to break during initialization. Changed
it to POST_KERNEL.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/43645

Signed-off-by: Artur Hadasz <artur.hadasz@nordicsemi.no>