### PR TITLE
[nrf toup] ipc: backends: rpmsg: initialize shared memory to zero

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -480,15 +480,17 @@ static int backend_init(const struct device *instance)
 	return 0;
 }
 
-#define DEFINE_BACKEND_DEVICE(i)							\
-	static struct backend_config_t backend_config_##i = {				\
-		.role = DT_ENUM_IDX_OR(DT_DRV_INST(i), role, ROLE_HOST),		\
-		.shm_size = DT_REG_SIZE(DT_INST_PHANDLE(i, memory_region)),		\
-		.shm_addr = DT_REG_ADDR(DT_INST_PHANDLE(i, memory_region)),		\
-		.mbox_tx = MBOX_DT_CHANNEL_GET(DT_DRV_INST(i), tx),			\
-		.mbox_rx = MBOX_DT_CHANNEL_GET(DT_DRV_INST(i), rx),			\
-	};										\
-											\
+#define BACKEND_CONFIG_POPULATE(i)						\
+	{									\
+		.role = DT_ENUM_IDX_OR(DT_DRV_INST(i), role, ROLE_HOST),	\
+		.shm_size = DT_REG_SIZE(DT_INST_PHANDLE(i, memory_region)),	\
+		.shm_addr = DT_REG_ADDR(DT_INST_PHANDLE(i, memory_region)),	\
+		.mbox_tx = MBOX_DT_CHANNEL_GET(DT_DRV_INST(i), tx),		\
+		.mbox_rx = MBOX_DT_CHANNEL_GET(DT_DRV_INST(i), rx),		\
+	}
+
+#define BACKEND_DEVICE_DEFINE(i)							\
+	static struct backend_config_t backend_config_##i = BACKEND_CONFIG_POPULATE(i);	\
 	static struct backend_data_t backend_data_##i;					\
 											\
 	DEVICE_DT_INST_DEFINE(i,							\
@@ -500,4 +502,26 @@ static int backend_init(const struct device *instance)
 			 CONFIG_IPC_SERVICE_REG_BACKEND_PRIORITY,			\
 			 &backend_ops);
 
-DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(BACKEND_DEVICE_DEFINE)
+
+#define BACKEND_CONFIG_DEFINE(i) BACKEND_CONFIG_POPULATE(i),
+
+static int shared_memory_prepare(const struct device *arg)
+{
+	const struct backend_config_t *backend_config;
+	const struct backend_config_t backend_configs[] = {
+		DT_INST_FOREACH_STATUS_OKAY(BACKEND_CONFIG_DEFINE)
+	};
+
+	for (backend_config = backend_configs;
+	     backend_config < backend_configs + ARRAY_SIZE(backend_configs);
+	     backend_config++) {
+		if (backend_config->role == ROLE_HOST) {
+			memset((void *) backend_config->shm_addr, 0, backend_config->shm_size);
+		}
+	}
+
+	return 0;
+}
+
+SYS_INIT(shared_memory_prepare, PRE_KERNEL_1, 1);


### PR DESCRIPTION
Added a code for initializing shared memory to zero. This operation
normalizes the memory state so that the IPC service is no longer
prone to reading status bits from the previous reset session.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>