### PR TITLE
[nrf fromlist] ipc: use highest coop priority for workqueue in new IP…

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -20,7 +20,7 @@
 
 #define DT_DRV_COMPAT	zephyr_ipc_openamp_static_vrings
 
-#define WQ_PRIORITY	(0)
+#define WQ_PRIORITY		K_HIGHEST_APPLICATION_THREAD_PRIO
 #define WQ_STACK_SIZE	CONFIG_IPC_SERVICE_BACKEND_RPMSG_WQ_STACK_SIZE
 
 #define STATE_READY	(0)


### PR DESCRIPTION
This is introduced to fix some errors, needs to be tested on sdk-nrf